### PR TITLE
Fixed ExtendedSearchQuerys postal code parameter

### DIFF
--- a/src/main/java/fr/dudie/nominatim/client/request/ExtendedSearchQuery.java
+++ b/src/main/java/fr/dudie/nominatim/client/request/ExtendedSearchQuery.java
@@ -56,7 +56,7 @@ public class ExtendedSearchQuery extends SearchQuery {
     private String country;
 
     /** A postal code. */
-    @QueryParameter("postal_code=%s")
+    @QueryParameter("postalcode=%s")
     private String postalCode;
 
     /**


### PR DESCRIPTION
The parameter name for postal code in the ExtendedSearchQuery is postalcode instead of postal_code.
(http://wiki.openstreetmap.org/wiki/Nominatim#Parameters)