### PR TITLE
Add JTS geometry/GeoJson support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation, either version 3 of the
   License, or (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Lesser Public License for more details.
-  
+
   You should have received a copy of the GNU General Lesser Public
   License along with this program.  If not, see
   <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -57,12 +57,16 @@
 
     <properties>
         <!-- compile time deps versions -->
-        <slf4j.version>1.6.1</slf4j.version>
-        <httpcomponents.version>4.0.2</httpcomponents.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <httpcomponents.version>4.0.3</httpcomponents.version>
 
         <!-- test deps versions -->
-        <junit.version>4.8.2</junit.version>
-        <commons-lang.version>2.6</commons-lang.version>
+        <junit.version>4.12</junit.version>
+        <commons-lang3.version>3.5</commons-lang3.version>
+
+        <!-- GSON deps versions -->
+        <gson.version>2.6.2</gson.version>
+        <geogson-jts.version>1.1.100</geogson-jts.version>
     </properties>
 
     <dependencies>
@@ -74,7 +78,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.1</version>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.filosganga</groupId>
+            <artifactId>geogson-jts</artifactId>
+            <version>${geogson-jts.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -89,9 +98,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/fr/dudie/nominatim/client/JsonNominatimClient.java
+++ b/src/main/java/fr/dudie/nominatim/client/JsonNominatimClient.java
@@ -32,6 +32,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.filosganga.geogson.gson.GeometryAdapterFactory;
+import com.github.filosganga.geogson.jts.JtsAdapterFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -176,6 +178,9 @@ public final class JsonNominatimClient implements NominatimClient {
         gsonBuilder.registerTypeAdapter(PolygonPoint.class, new PolygonPointDeserializer());
         gsonBuilder.registerTypeAdapter(PolygonPoint[].class, new ArrayOfPolygonPointsDeserializer());
         gsonBuilder.registerTypeAdapter(BoundingBox.class, new BoundingBoxDeserializer());
+
+        gsonBuilder.registerTypeAdapterFactory(new JtsAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new GeometryAdapterFactory());
 
         gsonInstance = gsonBuilder.create();
 

--- a/src/main/java/fr/dudie/nominatim/model/Address.java
+++ b/src/main/java/fr/dudie/nominatim/model/Address.java
@@ -23,6 +23,7 @@ package fr.dudie.nominatim.model;
  */
 
 import com.google.gson.annotations.SerializedName;
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * Represents a search result.
@@ -93,8 +94,13 @@ public final class Address {
     private BoundingBox boundingBox;
 
     /** The polygon points representing the element. */
+    @Deprecated
     @SerializedName("polygonpoints")
     private PolygonPoint[] polygonPoints;
+
+    /** The geojson representing the element. */
+    @SerializedName("geojson")
+    private Geometry geojson;
 
     /** The address longitude. */
     @SerializedName("lon")
@@ -266,6 +272,20 @@ public final class Address {
     }
 
     /**
+	 * @return the geojson
+	 */
+	public Geometry getGeojson() {
+		return geojson;
+	}
+
+	/**
+	 * @param geojson the geojson to set
+	 */
+	public void setGeojson(Geometry geojson) {
+		this.geojson = geojson;
+	}
+
+	/**
      * Gets the address longitude.
      * 
      * @return the address longitude

--- a/src/test/java/fr/dudie/nominatim/client/JsonNominatimClientTest.java
+++ b/src/test/java/fr/dudie/nominatim/client/JsonNominatimClientTest.java
@@ -33,8 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.PlainSocketFactory;

--- a/src/test/java/fr/dudie/nominatim/client/JsonNominatimClientTest.java
+++ b/src/test/java/fr/dudie/nominatim/client/JsonNominatimClientTest.java
@@ -47,8 +47,11 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vividsolutions.jts.geom.Geometry;
+
 import fr.dudie.nominatim.client.request.NominatimLookupRequest;
 import fr.dudie.nominatim.client.request.NominatimSearchRequest;
+import fr.dudie.nominatim.client.request.paramhelper.PolygonFormat;
 import fr.dudie.nominatim.model.Address;
 
 /**
@@ -106,6 +109,7 @@ public final class JsonNominatimClientTest {
         assertNotNull("a result should be found", address);
         assertTrue("address expose the OSM place_id", address.getPlaceId() > 0);
         assertNull("no polygonpoint", address.getPolygonPoints());
+        assertNull("no geojson", address.getGeojson());
 
         LOGGER.info("testGetAddress.end");
     }
@@ -125,6 +129,29 @@ public final class JsonNominatimClientTest {
         assertTrue("list is not empty", !addresses.isEmpty());
 
         LOGGER.info("testSearchWithResults.end");
+    }
+
+    @Test
+    public void testSearchWithGeoJsonResults() throws IOException {
+
+        LOGGER.info("testSearchWithGeoJsonResults.start");
+
+        NominatimSearchRequest request = new NominatimSearchRequest();
+        request.setPolygonFormat(PolygonFormat.GEO_JSON);
+        request.setQuery("vitré, rennes");
+
+        final List<Address> addresses = nominatimClient.search(request);
+
+        assertNotNull("result list is never null", addresses);
+        assertTrue("list is not empty", !addresses.isEmpty());
+
+        for (final Address address : addresses) {
+            final Geometry geom = address.getGeojson();
+            assertNotNull("geometry/geojson of address is available in result", geom);
+            assertTrue("geometry/geojson of address has at least one vertex", geom.getNumPoints() > 0);
+        }
+
+        LOGGER.info("testSearchWithGeoJsonResults.end");
     }
 
     @Test


### PR DESCRIPTION
As already proposed in https://github.com/jeremiehuchet/nominatim-java-api/pull/23, it would be nice to have the ability to access the geometries of addresses. Currently, this is not possible as `polygonpoints` is deprecated (and always null in the address results!?).

When using the `PolygonFormat.GEO_JSON` format, geojson will be inlcuded in the result sets , but it has not yet been deserialized by GSON.

To solve this problem, this PR

* adds a `geojson` field to the `Address` model. The type of the new field is `com.vividsolutions.jts.geom.Geometry` from the popular JTS library.
* adds a new dependency `geogson-jts` to register its `JtsAdapterFactory` and `GeometryAdapterFactory` to the `gsonBuilder`, so that the GeoJson can easily be deserialized by Gson (as described [here](https://github.com/filosganga/geogson#jts-support))

I also added a test to check the new functionality.
On top of that, some of the dependencies in the POM have been updated.